### PR TITLE
Optimization in case of app removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,3 +48,8 @@
 ## 1.0.8
 
 * Set Min SDK version 21.
+
+
+## 1.0.9
+
+* Optimized the refresh speed in case of removal of any application.

--- a/android/src/main/kotlin/com/example/get_apps/event_channel/events/PackageActionReceiver.kt
+++ b/android/src/main/kotlin/com/example/get_apps/event_channel/events/PackageActionReceiver.kt
@@ -27,13 +27,12 @@ class ActionReceiver(private var getApps: GetApps) : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
         if (intent != null && intent.action in actionMapping){
             val packageName = intent.data.toString().replaceFirst("package:", "")
-//            As removeAppFromList is not working as expected commented this for now
-//            if (intent.action == Intent.ACTION_PACKAGE_REMOVED){
-//                getApps.removeAppFromList(packageName)
-//            }
-//            if (intent.action == Intent.ACTION_PACKAGE_ADDED){
+            if (intent.action == Intent.ACTION_PACKAGE_REMOVED){
+                getApps.removeAppFromList(packageName)
+            }
+            if (intent.action == Intent.ACTION_PACKAGE_ADDED){
                 getApps.setApps()
-//            }
+            }
             callback.onNotify(packageName, actionMapping[intent.action]!!, events)
         }
     }

--- a/android/src/main/kotlin/com/example/get_apps/method_channel/GetApps.kt
+++ b/android/src/main/kotlin/com/example/get_apps/method_channel/GetApps.kt
@@ -110,17 +110,15 @@ class GetApps internal constructor(ctx: Context) {
         }
     }
 
-//    For now as it is not working we're refreshing the app list on add and remove both
-//    will make it work soon
-//    fun removeAppFromList(packageName: String) {
-//        Companion.allApps = Companion.allApps.filter {
-//            it["packageName"].toString() != packageName
-//        } as ArrayList<Map<String, Any>>
-//
-//        Companion.userApps = Companion.userApps.filter {
-//            it["packageName"].toString() != packageName
-//        } as ArrayList<Map<String, Any>>
-//    }
+    fun removeAppFromList(packageName: String) {
+        Companion.allApps = Companion.allApps.filter {
+            it["appPackage"].toString() != packageName
+        } as ArrayList<Map<String, Any>>
+
+        Companion.userApps = Companion.userApps.filter {
+            it["appPackage"].toString() != packageName
+        } as ArrayList<Map<String, Any>>
+    }
 
     companion object {
         @SuppressLint("StaticFieldLeak")

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -81,7 +81,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.7"
+    version: "1.0.8"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: get_apps
 description: Flutter Plugin to get all installed apps on android.
-version: 1.0.8
+version: 1.0.9
 homepage: https://github.com/TanmayMudgal619/get_apps
 
 environment:


### PR DESCRIPTION
## Overview:
Rather than querying all the applications again when an app is removed(uninstalled), now we are simply removing the app from list.

## Changes:
1. Added `removeAppFromList` to remove any package from apps list on the basis of `packageName`.
2. Used `removeAppFromList` in `PackageActionReceiver.kt` when an event for package removed is triggered.
3. Upgraded the version of `get_apps` to `1.0.9`.