### PR TITLE
Refresh speed when new app is installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,3 +53,8 @@
 ## 1.0.9
 
 * Optimized the refresh speed in case of removal of any application.
+
+
+## 1.0.10
+
+* Optimized the refresh speed in case of addition of any application.

--- a/android/src/main/kotlin/com/example/get_apps/event_channel/events/PackageActionReceiver.kt
+++ b/android/src/main/kotlin/com/example/get_apps/event_channel/events/PackageActionReceiver.kt
@@ -31,7 +31,7 @@ class ActionReceiver(private var getApps: GetApps) : BroadcastReceiver() {
                 getApps.removeAppFromList(packageName)
             }
             if (intent.action == Intent.ACTION_PACKAGE_ADDED){
-                getApps.setApps()
+                getApps.addAppInList(packageName, null)
             }
             callback.onNotify(packageName, actionMapping[intent.action]!!, events)
         }

--- a/android/src/main/kotlin/com/example/get_apps/method_channel/GetApps.kt
+++ b/android/src/main/kotlin/com/example/get_apps/method_channel/GetApps.kt
@@ -31,10 +31,7 @@ class GetApps internal constructor(ctx: Context) {
         Companion.userApps = ArrayList()
         val installedApps = packageManager.getInstalledApplications(0)
         for (applicationInfo in installedApps) {
-            Companion.allApps.add(getAppInfo(packageManager, applicationInfo))
-            if (packageManager.getLaunchIntentForPackage(applicationInfo.packageName) != null) {
-                Companion.userApps.add(getAppInfo(packageManager, applicationInfo))
-            }
+            addAppInList(applicationInfo.packageName, applicationInfo)
         }
     }
 
@@ -118,6 +115,15 @@ class GetApps internal constructor(ctx: Context) {
         Companion.userApps = Companion.userApps.filter {
             it["appPackage"].toString() != packageName
         } as ArrayList<Map<String, Any>>
+    }
+
+    fun addAppInList(packageName: String, applicationInfo: ApplicationInfo?) {
+        val packageManager = context.packageManager;
+        val appInfo = applicationInfo ?: packageManager.getApplicationInfo(packageName, 0)
+        Companion.allApps.add(getAppInfo(packageManager, appInfo))
+        if (packageManager.getLaunchIntentForPackage(appInfo.packageName) != null) {
+            Companion.userApps.add(getAppInfo(packageManager, appInfo))
+        }
     }
 
     companion object {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -81,7 +81,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.8"
+    version: "1.0.9"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: get_apps
 description: Flutter Plugin to get all installed apps on android.
-version: 1.0.9
+version: 1.0.10
 homepage: https://github.com/TanmayMudgal619/get_apps
 
 environment:


### PR DESCRIPTION
## Overview:
Rather than querying all the applications again when an app is added(installed), now we are simply adding the app in list.

## Changes:
1. Added `addAppInList` to remove any package from apps list on the basis of `packageName`.
2. Used `addAppInList` in `PackageActionReceiver.kt` when an event for package removed is triggered.
3. Upgraded the version of `get_apps` to `1.0.10`.