### PR TITLE
Removed Race condition in case of Initialization and other method Calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,3 +64,8 @@
 
 * Static Initializer for the GetApps.
 * All the functional calls are now moved from main thread to secondary threads.
+
+
+## 2.0.1
+
+* Removed Race condition for initialization and other method calls.

--- a/android/src/main/kotlin/com/example/get_apps/GetApps.kt
+++ b/android/src/main/kotlin/com/example/get_apps/GetApps.kt
@@ -32,7 +32,6 @@ class GetApps internal constructor(ctx: Context) {
                 return
             }
 
-            isInitialized = true
             Log.d("GetApps", "initCore: initializing get apps...")
             val packageManager = context.packageManager
             systemApps = ArrayList()
@@ -41,6 +40,7 @@ class GetApps internal constructor(ctx: Context) {
             for (applicationInfo in installedApps) {
                 addAppInList(applicationInfo.packageName, applicationInfo)
             }
+            isInitialized = true
 
         }
     }
@@ -92,8 +92,17 @@ class GetApps internal constructor(ctx: Context) {
         this.activity = activity
     }
 
-    fun removeAppFromList(packageName: String) {
+    fun removeApp(packageName: String){
         initCheck()
+        removeAppFromList(packageName)
+    }
+
+    fun addApp(packageName: String){
+        initCheck()
+        addAppInList(packageName, null)
+    }
+
+    private fun removeAppFromList(packageName: String) {
         systemApps = systemApps.filter {
             it["appPackage"].toString() != packageName
         } as ArrayList<Map<String, Any>>
@@ -103,8 +112,7 @@ class GetApps internal constructor(ctx: Context) {
         } as ArrayList<Map<String, Any>>
     }
 
-    fun addAppInList(packageName: String, applicationInfo: ApplicationInfo?) {
-        initCheck()
+    private fun addAppInList(packageName: String, applicationInfo: ApplicationInfo?) {
         val packageManager = context.packageManager;
         val appInfo = applicationInfo ?: packageManager.getApplicationInfo(packageName, 0)
         if (packageManager.getLaunchIntentForPackage(appInfo.packageName) != null) {
@@ -114,6 +122,7 @@ class GetApps internal constructor(ctx: Context) {
             systemApps.add(getAppInfo(packageManager, appInfo))
         }
     }
+
 
     private fun getAppInfo(packageManager: PackageManager?, applicationInfo: ApplicationInfo): Map<String, Any> {
         val drawable = applicationInfo.loadIcon(packageManager)

--- a/android/src/main/kotlin/com/example/get_apps/event_channel/events/PackageActionReceiver.kt
+++ b/android/src/main/kotlin/com/example/get_apps/event_channel/events/PackageActionReceiver.kt
@@ -28,10 +28,10 @@ class ActionReceiver(private var getApps: GetApps) : BroadcastReceiver() {
         if (intent != null && intent.action in actionMapping){
             val packageName = intent.data.toString().replaceFirst("package:", "")
             if (intent.action == Intent.ACTION_PACKAGE_REMOVED){
-                getApps.removeAppFromList(packageName)
+                getApps.removeApp(packageName)
             }
             if (intent.action == Intent.ACTION_PACKAGE_ADDED){
-                getApps.addAppInList(packageName, null)
+                getApps.addApp(packageName)
             }
             callback.onNotify(packageName, actionMapping[intent.action]!!, events)
         }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -81,7 +81,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.10"
+    version: "2.0.1"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: get_apps
 description: Flutter Plugin to get all installed apps on android.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/TanmayMudgal619/get_apps
 
 environment:


### PR DESCRIPTION
## Overview
With Previous implementation of initialization we had a race condition on `isInitialized` as the field is set to true even before fetching all the apps.
So now that has been changes.

## Changes
* Added two new public method `addApp` and `removeApp` in `GetApps.kt`.
* Made `addAppToList` and `removeAppFromList` private.
* Upgraded the version to `2.0.1`.