### PR TITLE
Removed explicit init method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,3 +69,9 @@
 ## 2.0.1
 
 * Removed Race condition for initialization and other method calls.
+
+
+## 3.0.0
+
+* Removed `init` method as wasn't much useful, now any call to native code will trigger
+  initialization if not done already.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ For now code is not organized due to some urgency on my side but soon the whole 
 For now I'm not very consistent with the way I make change but soon there will a defined way to make changes in this repo.
 
 ## TODO
-- [ ] Adding a stream method to continously listen all apps rather then fetching them again manually on add/remove events.
 - [ ] Add more details regarding apps, such as their version.
-- [ ] `init` should be called automatically if hasn't been called before, rather than showing an error.
 - [ ] Valid Test Cases.
 - [ ] How about supporting other platforms too?
+- [ ] Adding a stream method to continuously listen all apps rather then fetching them again manually on add/remove events.
+- [x] `init` should be called automatically if hasn't been called before, rather than showing an error.
 
 ## Usage
 
@@ -46,12 +46,10 @@ class _MyAppState extends State<MyApp> {
 
   @override
   void initState() {
-    userApps = GetApps.init().then((_){
-      GetApps().appActionReceiver().forEach((packageAction){
-        userApps = GetApps().getApps();
-        setState(() {});
-      });
-      return GetApps().getApps();
+    userApps = GetApps().getApps();
+    GetApps().appActionReceiver().forEach((packageAction){
+      userApps = GetApps().getApps();
+      setState(() {});
     });
     super.initState();
   }

--- a/android/src/main/kotlin/com/example/get_apps/GetApps.kt
+++ b/android/src/main/kotlin/com/example/get_apps/GetApps.kt
@@ -41,7 +41,6 @@ class GetApps internal constructor(ctx: Context) {
                 addAppInList(applicationInfo.packageName, applicationInfo)
             }
             isInitialized = true
-
         }
     }
 
@@ -84,7 +83,7 @@ class GetApps internal constructor(ctx: Context) {
 
     fun initCheck(){
         if (!isInitialized){
-            throw Exception("Get Apps is not initialized!")
+            initCore()
         }
     }
 

--- a/android/src/main/kotlin/com/example/get_apps/event_channel/EventChannelHandler.kt
+++ b/android/src/main/kotlin/com/example/get_apps/event_channel/EventChannelHandler.kt
@@ -3,6 +3,8 @@ package com.example.get_apps.event_channel
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.os.Handler
+import android.os.Looper
 import com.example.get_apps.event_channel.events.ActionReceiver
 import com.example.get_apps.event_channel.events.OnPackageActionNotify
 import com.example.get_apps.GetApps
@@ -28,10 +30,14 @@ class EventChannelHandler: StreamHandler {
   }
 
   override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
-    getApps.initCheck()
-    actionReceiver.setEventSink(events);
-    actionReceiver.setListener(OnPackageActionNotify())
-    context.registerReceiver(actionReceiver, packageIntentFilter)
+    Thread{
+      getApps.initCheck()
+      Handler(Looper.getMainLooper()).post {
+        actionReceiver.setEventSink(events);
+        actionReceiver.setListener(OnPackageActionNotify())
+        context.registerReceiver(actionReceiver, packageIntentFilter)
+      }
+    }.start()
   }
 
   override fun onCancel(arguments: Any?) {

--- a/android/src/main/kotlin/com/example/get_apps/event_channel/events/OnPackageActionNotify.kt
+++ b/android/src/main/kotlin/com/example/get_apps/event_channel/events/OnPackageActionNotify.kt
@@ -1,9 +1,13 @@
 package com.example.get_apps.event_channel.events
 
+import android.os.Handler
+import android.os.Looper
 import io.flutter.plugin.common.EventChannel
 
 class OnPackageActionNotify : PackageActionListerner() {
   override fun onNotify(packageName: String, action: String, events: EventChannel.EventSink?) {
-    events?.success(PackageNotification(packageName, action).toJson());
+    Handler(Looper.getMainLooper()).post {
+      events?.success(PackageNotification(packageName, action).toJson());
+    }
   }
 }

--- a/android/src/main/kotlin/com/example/get_apps/method_channel/MethodChannelHandler.kt
+++ b/android/src/main/kotlin/com/example/get_apps/method_channel/MethodChannelHandler.kt
@@ -27,20 +27,12 @@ class MethodChannelHandler: MethodCallHandler {
   override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
     Thread{
       when(call.method){
-        "init"-> initHandler(result)
         "getApps"-> getAppsHandler(call, result)
         "openApp" -> openAppHandler(call, result)
         "deleteApp" -> deleteAppHandler(call, result)
         else -> result.notImplemented()
       }
     }.start()
-  }
-
-  fun initHandler(result: MethodChannel.Result){
-    this.getApps.initCore()
-    Handler(Looper.getMainLooper()).post {
-      result.success(null)
-    }
   }
 
   fun getAppsHandler(call: MethodCall, result: MethodChannel.Result){

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -19,12 +19,10 @@ class _MyAppState extends State<MyApp> {
 
   @override
   void initState() {
-    userApps = GetApps.init().then((_){
-      GetApps().appActionReceiver().forEach((packageAction){
-        userApps = GetApps().getApps();
-        setState(() {});
-      });
-      return GetApps().getApps();
+    userApps = GetApps().getApps();
+    GetApps().appActionReceiver().forEach((packageAction){
+      userApps = GetApps().getApps();
+      setState(() {});
     });
     super.initState();
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -81,7 +81,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.1"
+    version: "3.0.0"
   leak_tracker:
     dependency: transitive
     description:

--- a/lib/get_apps.dart
+++ b/lib/get_apps.dart
@@ -3,10 +3,6 @@ import 'models.dart';
 
 class GetApps {
 
-  static Future<void> init(){
-    return GetAppsPlatform.instance.init();
-  }
-
   Future<List<AppInfo>> getApps({bool includeSystemApps = false}) {
     return GetAppsPlatform.instance.getApps(includeSystemApps: includeSystemApps);
   }

--- a/lib/get_apps_method_channel.dart
+++ b/lib/get_apps_method_channel.dart
@@ -12,11 +12,6 @@ class MethodChannelGetApps extends GetAppsPlatform {
   final eventChannel = const EventChannel('event_channel');
 
   @override
-  Future<void> init() async {
-    await methodChannel.invokeMethod('init');
-  }
-
-  @override
   Future<List<AppInfo>> getApps({bool includeSystemApps = false}) async {
     try{
       final List<dynamic> result = await methodChannel.invokeMethod('getApps', {"includeSystemApps": includeSystemApps});

--- a/lib/get_apps_platform_interface.dart
+++ b/lib/get_apps_platform_interface.dart
@@ -24,10 +24,6 @@ abstract class GetAppsPlatform extends PlatformInterface {
     _instance = instance;
   }
 
-  Future<void> init() {
-    throw UnimplementedError('init() has not been implemented.');
-  }
-
   Future<List<AppInfo>> getApps({bool includeSystemApps = false}) {
     throw UnimplementedError('getApps() has not been implemented.');
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: get_apps
 description: Flutter Plugin to get all installed apps on android.
-version: 2.0.1
+version: 3.0.0
 homepage: https://github.com/TanmayMudgal619/get_apps
 
 environment:

--- a/test/get_apps_test.dart
+++ b/test/get_apps_test.dart
@@ -24,10 +24,6 @@ class MockGetAppsPlatform
     throw UnimplementedError();
   }
 
-  @override
-  Future<void> init() {
-    throw UnimplementedError();
-  }
 }
 
 void main() {


### PR DESCRIPTION
## Overview
Explicit `init` method didn't made much sense. So removed it, now any call to native code will trigger initialization if not done already.

## Changes
* Removed `init` method.
* Called `initCore` in `initCheck` if not initialized already.
* Upgraded version to 3.0.0, as again a breaking change (I know I could have kept `init` intact and it would have been backward compatible but decided to remove it).