### PR TITLE
fix: add registration flag to avoid unregistering ActionReceiver not registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,3 +102,8 @@
 ## 4.1.2
 
 * Updated project status.
+
+## 4.1.3
+
+* Fix add registration flag to avoid unregistering ActionReceiver not registered
+* Fix Receiving a added broadcast but the app does not exist (possibly not installed yet) will throw an exception

--- a/android/src/main/kotlin/com/example/get_apps/GetApps.kt
+++ b/android/src/main/kotlin/com/example/get_apps/GetApps.kt
@@ -169,8 +169,12 @@ class GetApps internal constructor(ctx: Context) {
 
     private fun addAppInList(packageName: String, applicationInfo: ApplicationInfo?) {
         val packageManager = context.packageManager;
-        val appInfo = applicationInfo ?: packageManager.getApplicationInfo(packageName, 0)
-
+        val appInfo = try {
+            applicationInfo ?: packageManager.getApplicationInfo(packageName, 0)
+        } catch (e: Exception) {
+            Log.e("GetApps", "Error getting app info: $packageName", e)
+            return
+        }
         val appDataMap = getAppInfoMap(packageManager, appInfo)
         apps.add(appDataMap)
     }

--- a/android/src/main/kotlin/com/example/get_apps/event_channel/EventChannelHandler.kt
+++ b/android/src/main/kotlin/com/example/get_apps/event_channel/EventChannelHandler.kt
@@ -17,6 +17,7 @@ class EventChannelHandler: StreamHandler {
   private var getApps: GetApps
   private var actionReceiver : ActionReceiver
   private var packageIntentFilter: IntentFilter
+  private var isReceiverRegistered = false
 
   constructor(context: Context, getApps: GetApps){
     this.context = context
@@ -36,11 +37,20 @@ class EventChannelHandler: StreamHandler {
         actionReceiver.setEventSink(events);
         actionReceiver.setListener(OnPackageActionNotify())
         context.registerReceiver(actionReceiver, packageIntentFilter)
+        isReceiverRegistered = true
       }
     }.start()
   }
 
   override fun onCancel(arguments: Any?) {
-    context.unregisterReceiver(actionReceiver)
+    if(isReceiverRegistered) {
+      try {
+        // If the screen is rotated multiple times, errors may still occur
+        context.unregisterReceiver(actionReceiver)
+      }catch (e: Exception){
+        //ignored
+        isReceiverRegistered = false
+      }
+    }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: get_apps
 description: Flutter Plugin to get all installed apps on android.
-version: 4.1.2
+version: 4.1.3
 homepage: https://github.com/TanmayMudgal619/get_apps
 
 environment:


### PR DESCRIPTION
A crash occurred during app destruction (e.g. on screen rotation) when GetApps().appActionReceiver() was never called on the Flutter side. This will cause the application to crash
In this case, the plugin attempted to call unregisterReceiver() even though the ActionReceiver had not been registered, resulting in:
```java
java.lang.IllegalArgumentException: Receiver not registered: com.example.get_apps.event_channel.events.ActionReceiver
```